### PR TITLE
Actionsheet presentation style option

### DIFF
--- a/Proj/Demo.xcodeproj/project.pbxproj
+++ b/Proj/Demo.xcodeproj/project.pbxproj
@@ -372,10 +372,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = P599PJHMNF;
 				INFOPLIST_FILE = Demo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = xxxAIRINxxx.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -386,10 +388,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = P599PJHMNF;
 				INFOPLIST_FILE = Demo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = xxxAIRINxxx.Demo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Proj/Demo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Proj/Demo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Proj/Demo/Base.lproj/Main.storyboard
+++ b/Proj/Demo/Base.lproj/Main.storyboard
@@ -1,7 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="cqI-EF-Apd">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="cqI-EF-Apd">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,13 +16,14 @@
                         <viewControllerLayoutGuide type="bottom" id="9eH-ZA-lWs"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="S8G-Qf-gr1">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hfk-F6-n2F">
+                                <rect key="frame" x="113" y="246" width="188" height="404"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O66-B2-VAj">
-                                        <frame key="frameInset" minX="48" minY="88" width="93" height="30"/>
+                                        <rect key="frame" x="48" y="88" width="93" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Single Button">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -30,7 +33,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tfC-wk-MZU">
-                                        <frame key="frameInset" minX="45" minY="138" width="99" height="30"/>
+                                        <rect key="frame" x="45" y="138" width="99" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Double Button">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -40,7 +43,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vaS-5N-3HY">
-                                        <frame key="frameInset" minX="60" minY="42" width="68" height="30"/>
+                                        <rect key="frame" x="60" y="42" width="68" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="No Action">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -50,7 +53,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eGS-ZJ-GNq">
-                                        <frame key="frameInset" minX="38" minY="247" width="112" height="30"/>
+                                        <rect key="frame" x="38" y="247" width="112" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Roll Alert">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -60,13 +63,13 @@
                                         </connections>
                                     </button>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="keyboard" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bPL-EF-cUr">
-                                        <frame key="frameInset" minX="46" minY="332" width="97" height="30"/>
+                                        <rect key="frame" x="46" y="332" width="97" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PLt-Tp-HXZ">
-                                        <frame key="frameInset" minX="79" minY="290" width="30" height="30"/>
+                                        <rect key="frame" x="79" y="290" width="30" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Text">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -76,13 +79,13 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V3U-73-V5D">
-                                        <frame key="frameInset" minX="11" minY="194" width="167" height="30"/>
+                                        <rect key="frame" x="11" y="194" width="167" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <state key="normal" title="Triple Button">
+                                        <state key="normal" title="Destructive Button">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <connections>
-                                            <action selector="tripleButtonAlert" destination="cqI-EF-Apd" eventType="touchUpInside" id="lcK-as-zOv"/>
+                                            <action selector="destructiveButtonAlert" destination="cqI-EF-Apd" eventType="touchUpInside" id="cJO-Lr-jUJ"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/Proj/Demo/Base.lproj/Main.storyboard
+++ b/Proj/Demo/Base.lproj/Main.storyboard
@@ -2,7 +2,6 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="cqI-EF-Apd">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,11 +18,11 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hfk-F6-n2F">
-                                <rect key="frame" x="113" y="246" width="188" height="404"/>
+                            <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hfk-F6-n2F">
+                                <rect key="frame" x="93" y="217" width="229" height="500"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O66-B2-VAj">
-                                        <rect key="frame" x="48" y="88" width="93" height="30"/>
+                                        <rect key="frame" x="66" y="72" width="93" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Single Button">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -33,7 +32,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tfC-wk-MZU">
-                                        <rect key="frame" x="45" y="138" width="99" height="30"/>
+                                        <rect key="frame" x="63" y="122" width="99" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Double Button">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -43,7 +42,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vaS-5N-3HY">
-                                        <rect key="frame" x="60" y="42" width="68" height="30"/>
+                                        <rect key="frame" x="78" y="26" width="68" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="No Action">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -52,8 +51,39 @@
                                             <action selector="noActionButtonAlert" destination="cqI-EF-Apd" eventType="touchUpInside" id="nur-1f-G4H"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V3U-73-V5D">
+                                        <rect key="frame" x="29" y="167" width="167" height="30"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Destructive Button">
+                                            <color key="titleColor" systemColor="systemRedColor" red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="destructiveButtonAlert" destination="cqI-EF-Apd" eventType="touchUpInside" id="cJO-Lr-jUJ"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jp2-3I-gHA">
+                                        <rect key="frame" x="29" y="232" width="167" height="30"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Show as action sheet">
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="actionSheetdoubleButtonAlert" destination="cqI-EF-Apd" eventType="touchUpInside" id="Nv3-ix-JGz"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="za6-2j-Vc6">
+                                        <rect key="frame" x="9" y="276" width="212" height="30"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Show as action sheet triple btn">
+                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="actionSheetDestructiveButtonAlert" destination="cqI-EF-Apd" eventType="touchUpInside" id="twM-Er-w6z"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eGS-ZJ-GNq">
-                                        <rect key="frame" x="38" y="247" width="112" height="30"/>
+                                        <rect key="frame" x="58" y="354" width="112" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Roll Alert">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -63,29 +93,19 @@
                                         </connections>
                                     </button>
                                     <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="keyboard" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bPL-EF-cUr">
-                                        <rect key="frame" x="46" y="332" width="97" height="30"/>
+                                        <rect key="frame" x="66" y="439" width="97" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PLt-Tp-HXZ">
-                                        <rect key="frame" x="79" y="290" width="30" height="30"/>
+                                        <rect key="frame" x="99" y="397" width="30" height="30"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="Text">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
                                         <connections>
                                             <action selector="textAlert" destination="cqI-EF-Apd" eventType="touchUpInside" id="n0z-XE-bf4"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="V3U-73-V5D">
-                                        <rect key="frame" x="11" y="194" width="167" height="30"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <state key="normal" title="Destructive Button">
-                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="destructiveButtonAlert" destination="cqI-EF-Apd" eventType="touchUpInside" id="cJO-Lr-jUJ"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -105,7 +125,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="VbW-k3-EFn" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="199" y="408"/>
+            <point key="canvasLocation" x="198.55072463768118" y="407.8125"/>
         </scene>
     </scenes>
 </document>

--- a/Proj/Demo/Info.plist
+++ b/Proj/Demo/Info.plist
@@ -35,6 +35,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/Proj/Demo/ViewController.swift
+++ b/Proj/Demo/ViewController.swift
@@ -49,6 +49,34 @@ final class ViewController: UIViewController {
             .show()
     }
     
+    @IBAction func actionSheetdoubleButtonAlert() {
+        SwAlert(title: "double action title", message: "double action message")
+            .addAction("double action 1") { result in
+                print("double action 1 completion")
+        }
+        .setCancelAction("cancel action") { result in
+            print("cancel action completion")
+        }
+        .showAsActionSheet()
+    }
+    
+    @IBAction func actionSheetDestructiveButtonAlert() {
+        SwAlert(title: "another destructive action title", message: "destructive action message")
+            .addAction("triple action 1") { result in
+                print("triple action 1 completion")
+        }
+        .addAction("triple action 2") { result in
+            print("triple action 2 completion")
+        }
+        .addDestructiveAction("DESTROY!!!!") { result in
+            print("pressed DESTROY!!!! button")
+        }
+        .setCancelAction("cancel action") { result in
+            print("cancel triple action completion")
+        }
+        .showAsActionSheet()
+    }
+    
     @IBAction func rollAlert() {
         for index in 0..<3 {
             SwAlert(title: "roll action " + String(index) + " title", message: "roll action " + String(index) + " message")

--- a/Proj/Demo/ViewController.swift
+++ b/Proj/Demo/ViewController.swift
@@ -32,13 +32,16 @@ final class ViewController: UIViewController {
             .show()
     }
     
-    @IBAction func tripleButtonAlert() {
-        SwAlert(title: "triple action title", message: "triple action message")
+    @IBAction func destructiveButtonAlert() {
+        SwAlert(title: "destructive action title", message: "destructive action message")
             .addAction("triple action 1") { result in
                 print("triple action 1 completion")
             }
             .addAction("triple action 2") { result in
                 print("triple action 2 completion")
+            }
+            .addDestructiveAction("DESTROY!") { result in
+                print("pressed DESTROY! button")
             }
             .setCancelAction("cancel action") { result in
                 print("cancel triple action completion")

--- a/Proj/SwAlert.xcodeproj/project.pbxproj
+++ b/Proj/SwAlert.xcodeproj/project.pbxproj
@@ -347,6 +347,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/../Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = xxxAIRINxxx.SwAlert;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -365,6 +366,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/../Sources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = xxxAIRINxxx.SwAlert;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Sources/SwAlert.swift
+++ b/Sources/SwAlert.swift
@@ -77,7 +77,7 @@ public final class SwAlert: NSObject, UIAlertViewDelegate {
     }
     
     
-  
+    
     
     // MARK: - Initializer
     
@@ -100,9 +100,9 @@ public final class SwAlert: NSObject, UIAlertViewDelegate {
     }
     
     public func addDestructiveAction(_ buttonTitle: String, _ completion: CompletionHandler? = nil) -> SwAlert {
-      let alertInfo = AlertInfo(type: .destructive(title: buttonTitle), completion: completion)
-      self.alertInfo.append(alertInfo)
-      return self
+        let alertInfo = AlertInfo(type: .destructive(title: buttonTitle), completion: completion)
+        self.alertInfo.append(alertInfo)
+        return self
     }
     
     public func addTextField(_ text: String, placeholder: String? = nil) -> SwAlert {
@@ -187,8 +187,12 @@ extension SwAlert {
                     textField.keyboardType = .numbersAndPunctuation
                     textField.enablesReturnKeyAutomatically = false
                     textField.placeholder = placeholder
-                    if UITraitCollection.current.userInterfaceStyle == .dark {
-                        textField.keyboardAppearance = .dark
+                    if #available(iOS 13.0, *) {
+                        if UITraitCollection.current.userInterfaceStyle == .dark {
+                            textField.keyboardAppearance = .dark
+                        }
+                    } else {
+                        // Fallback on earlier versions
                     }
                 })
             }

--- a/Sources/SwAlert.swift
+++ b/Sources/SwAlert.swift
@@ -76,6 +76,9 @@ public final class SwAlert: NSObject, UIAlertViewDelegate {
         alert.show()
     }
     
+    
+  
+    
     // MARK: - Initializer
     
     public init(title: String?, message: String?) {
@@ -109,7 +112,11 @@ public final class SwAlert: NSObject, UIAlertViewDelegate {
     }
     
     public func show() {
-        self.showAlertController()
+        self.showAlertController(.alert)
+    }
+    
+    public func showAsActionSheet() {
+        self.showAlertController(.actionSheet)
     }
     
     // MARK: - Private Functions
@@ -121,7 +128,7 @@ public final class SwAlert: NSObject, UIAlertViewDelegate {
 
 extension SwAlert {
     
-    fileprivate func showAlertController() {
+    fileprivate func showAlertController(_ preferred_style:UIAlertController.Style) {
         if AlertManager.sharedInstance.window.isKeyWindow {
             AlertManager.sharedInstance.alertQueue.append(self)
             return
@@ -130,7 +137,13 @@ extension SwAlert {
             AlertManager.sharedInstance.window.makeKeyAndVisible()
         }
         
-        let alertController = UIAlertController(title: self.title, message: self.message, preferredStyle: .alert)
+        var alertController = UIAlertController(title: self.title == "" ? nil : self.title, message: self.message == "" ? nil : self.message, preferredStyle: preferred_style)
+        
+        // for ipad, override the actionSheet style
+        if let popoverController = alertController.popoverPresentationController {
+            alertController = UIAlertController(title: self.title == "" ? nil : self.title, message: self.message == "" ? nil : self.message, preferredStyle: .alert)
+        }
+        
         
         if let _cancelInfo = self.cancelInfo {
             self.alertInfo.append(_cancelInfo)
@@ -171,7 +184,12 @@ extension SwAlert {
             case .textField(let text, let placeholder):
                 alertController.addTextField(configurationHandler: { textField in
                     textField.text = text
+                    textField.keyboardType = .numbersAndPunctuation
+                    textField.enablesReturnKeyAutomatically = false
                     textField.placeholder = placeholder
+                    if UITraitCollection.current.userInterfaceStyle == .dark {
+                        textField.keyboardAppearance = .dark
+                    }
                 })
             }
         }
@@ -182,6 +200,8 @@ extension SwAlert {
             })
             alertController.addAction(action)
         }
+        
+        
         
         AlertManager.sharedInstance.parentController.present(alertController, animated: true, completion: nil)
     }

--- a/Sources/SwAlert.swift
+++ b/Sources/SwAlert.swift
@@ -20,6 +20,7 @@ public typealias CompletionHandler = ((SwAlertResult) -> Void)
 public enum AlertButtonType {
     case cancel(title: String)
     case other(title: String)
+    case destructive(title: String)
     case textField(text: String, placeholder: String?)
 }
 
@@ -95,6 +96,12 @@ public final class SwAlert: NSObject, UIAlertViewDelegate {
         return self
     }
     
+    public func addDestructiveAction(_ buttonTitle: String, _ completion: CompletionHandler? = nil) -> SwAlert {
+      let alertInfo = AlertInfo(type: .destructive(title: buttonTitle), completion: completion)
+      self.alertInfo.append(alertInfo)
+      return self
+    }
+    
     public func addTextField(_ text: String, placeholder: String? = nil) -> SwAlert {
         let alertInfo = AlertInfo(type: .textField(text: text, placeholder: placeholder), completion: nil)
         self.alertInfo.append(alertInfo)
@@ -141,6 +148,17 @@ extension SwAlert {
                 alertController.addAction(action)
             case .other(let buttonTitle):
                 let action = UIAlertAction(title: buttonTitle, style: .default, handler: { action in
+                    SwAlert.dismiss()
+                    
+                    var inputText: [String] = []
+                    alertController.textFields?.forEach() {
+                        inputText.append($0.text ?? "")
+                    }
+                    info.completion?(.other(inputText: inputText))
+                })
+                alertController.addAction(action)
+            case .destructive(let buttonTitle):
+                let action = UIAlertAction(title: buttonTitle, style: .destructive, handler: { action in
                     SwAlert.dismiss()
                     
                     var inputText: [String] = []


### PR DESCRIPTION
Use `showAsActionSheet()` instead of `show()` to present the alert as an action sheet (iPhone only). On iPads, the alert is always shown with the alert style. See below.

---

Why no actionSheet style on iPads?

On iPads, presenting a UIAlertController requires a sender (UIBarButtonItem), or an explicit frame. this is easy enough to do using `AlertManager.sharedInstance.parentController`. But then the alert doesn't support device rotation. easier to just ignore the request for the actionSheet style on devices that use popoverPresentationControllers. 

to see what i mean, replace this
```
AlertManager.sharedInstance.parentController.present(alertController, animated: true, completion: nil)
```

with this
```
if let popoverController = alertController.popoverPresentationController {
  popoverController.sourceView = AlertManager.sharedInstance.parentController.view
  popoverController.sourceRect = CGRect(x: AlertManager.sharedInstance.parentController.view.bounds.midX, y: AlertManager.sharedInstance.parentController.view.bounds.midY, width: 0, height: 0)
  popoverController.permittedArrowDirections = []
}
AlertManager.sharedInstance.parentController.present(alertController, animated: true, completion: nil)
```

on an ipad and try rotation.